### PR TITLE
Merge edited response status in export

### DIFF
--- a/src/controllers/exportDataController.js
+++ b/src/controllers/exportDataController.js
@@ -639,8 +639,7 @@ class ExportDataController {
             if (arr.length >= 1) {
                 res.status(200).zip(arr);
             } else {
-                // TODO: change status code- error message is not displayed
-                res.status(204).json(ErrorHelper(message.userError.NOPATIENTDATA));
+                res.status(200).json(ErrorHelper(message.userError.NOPATIENTDATA));
             }
         }
     }


### PR DESCRIPTION
Status 204 was replaced by 200 to allow for the inclusion of a response body.

> A 204 response is terminated by the first empty line after the header fields because it cannot contain a message body

 at https://httpstatuses.com/204.

https://github.com/expressjs/express/blob/9375a9afa9d7baa814b454c7a6818a7471aaef00/lib/response.js